### PR TITLE
revert copyright

### DIFF
--- a/packages/k8s-workflow/gha-runner-rpc.py
+++ b/packages/k8s-workflow/gha-runner-rpc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This implements a very simple RPC server that should be running on the job container of the workflow pod,


### PR DESCRIPTION
2025 breaks splice header checks, and I'm too lazy to figure out how to exclude this submodule from them.