### PR TITLE
Add k8s APIs retry wrapper

### DIFF
--- a/packages/k8s/src/hooks/cleanup-job.ts
+++ b/packages/k8s/src/hooks/cleanup-job.ts
@@ -1,4 +1,4 @@
-import { prunePods, pruneServices, pruneSecrets } from '../k8s'
+import { prunePods, pruneServices, pruneSecrets } from '../k8s/retryWrappers'
 
 export async function cleanupJob(): Promise<void> {
   await Promise.all([prunePods(), pruneServices(), pruneSecrets()])

--- a/packages/k8s/src/hooks/cleanup-job.ts
+++ b/packages/k8s/src/hooks/cleanup-job.ts
@@ -1,4 +1,4 @@
-import { prunePods, pruneServices, pruneSecrets } from '../k8s/retryWrappers'
+import { prunePods, pruneServices, pruneSecrets } from '../k8s/retry-wrappers'
 
 export async function cleanupJob(): Promise<void> {
   await Promise.all([prunePods(), pruneServices(), pruneSecrets()])

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -16,7 +16,7 @@ import {
   waitForPodPhases,
   getPrepareJobTimeoutSeconds,
   createService,
-} from '../k8s/retryWrappers'
+} from '../k8s/retry-wrappers'
 import {
   containerVolumes,
   DEFAULT_CONTAINER_ENTRY_POINT,

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -16,7 +16,7 @@ import {
   waitForPodPhases,
   getPrepareJobTimeoutSeconds,
   createService,
-} from '../k8s'
+} from '../k8s/retryWrappers'
 import {
   containerVolumes,
   DEFAULT_CONTAINER_ENTRY_POINT,

--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -9,7 +9,7 @@ import {
   getPodStatus,
   waitForJobToComplete,
   waitForPodPhases
-} from '../k8s/retryWrappers'
+} from '../k8s/retry-wrappers'
 import {
   containerVolumes,
   fixArgs,

--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -9,7 +9,7 @@ import {
   getPodStatus,
   waitForJobToComplete,
   waitForPodPhases
-} from '../k8s'
+} from '../k8s/retryWrappers'
 import {
   containerVolumes,
   fixArgs,

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -7,7 +7,7 @@ import {
   runScriptStep
 } from './hooks'
 import { namespace, requiredPermissions } from './k8s'
-import { isAuthPermissionsOK } from './k8s/retryWrappers'
+import { isAuthPermissionsOK } from './k8s/retry-wrappers'
 
 async function run(): Promise<void> {
   try {

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -6,7 +6,8 @@ import {
   runContainerStep,
   runScriptStep
 } from './hooks'
-import { isAuthPermissionsOK, namespace, requiredPermissions } from './k8s'
+import { namespace, requiredPermissions } from './k8s'
+import { isAuthPermissionsOK } from './k8s/retryWrappers'
 
 async function run(): Promise<void> {
   try {

--- a/packages/k8s/src/k8s/retry-wrappers.ts
+++ b/packages/k8s/src/k8s/retry-wrappers.ts
@@ -69,78 +69,84 @@ async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
 
 // Retried API calls, only the ones the hooks import
 
-export const createPod = (
+export const createPod = async (
   jobContainer?: k8s.V1Container,
   services?: k8s.V1Container[],
   registry?: Registry,
   extension?: k8s.V1PodTemplateSpec
 ): Promise<k8s.V1Pod> =>
-  withRetry('createPod', () =>
+  withRetry('createPod', async () =>
     raw.createPod(jobContainer, services, registry, extension)
   )
 
-export const createService = (pod: k8s.V1Pod): Promise<k8s.V1Service> =>
-  withRetry('createService', () => raw.createService(pod))
+export const createService = async (pod: k8s.V1Pod): Promise<k8s.V1Service> =>
+  withRetry('createService', async () => raw.createService(pod))
 
-export const createJob = (
+export const createJob = async (
   container: k8s.V1Container,
   extension?: k8s.V1PodTemplateSpec
 ): Promise<k8s.V1Job> =>
-  withRetry('createJob', () => raw.createJob(container, extension))
+  withRetry('createJob', async () => raw.createJob(container, extension))
 
-export const getContainerJobPodName = (jobName: string): Promise<string> =>
-  withRetry('getContainerJobPodName', () => raw.getContainerJobPodName(jobName))
+export const getContainerJobPodName = async (
+  jobName: string
+): Promise<string> =>
+  withRetry('getContainerJobPodName', async () =>
+    raw.getContainerJobPodName(jobName)
+  )
 
-export const createSecretForEnvs = (envs: {
+export const createSecretForEnvs = async (envs: {
   [key: string]: string
 }): Promise<string> =>
-  withRetry('createSecretForEnvs', () => raw.createSecretForEnvs(envs))
+  withRetry('createSecretForEnvs', async () => raw.createSecretForEnvs(envs))
 
-export const getPodStatus = (
+export const getPodStatus = async (
   name: string
 ): Promise<k8s.V1PodStatus | undefined> =>
-  withRetry('getPodStatus', () => raw.getPodStatus(name))
+  withRetry('getPodStatus', async () => raw.getPodStatus(name))
 
-export const isAuthPermissionsOK = (): Promise<boolean> =>
-  withRetry('isAuthPermissionsOK', () => raw.isAuthPermissionsOK())
+export const isAuthPermissionsOK = async (): Promise<boolean> =>
+  withRetry('isAuthPermissionsOK', async () => raw.isAuthPermissionsOK())
 
-export const isPodContainerAlpine = (
+export const isPodContainerAlpine = async (
   podName: string,
   containerName: string
 ): Promise<boolean> =>
-  withRetry('isPodContainerAlpine', () =>
+  withRetry('isPodContainerAlpine', async () =>
     raw.isPodContainerAlpine(podName, containerName)
   )
 
-export const prunePods = (): Promise<void> =>
-  withRetry('prunePods', () => raw.prunePods())
+export const prunePods = async (): Promise<void> =>
+  withRetry('prunePods', async () => raw.prunePods())
 
-export const pruneServices = (): Promise<void> =>
-  withRetry('pruneServices', () => raw.pruneServices())
+export const pruneServices = async (): Promise<void> =>
+  withRetry('pruneServices', async () => raw.pruneServices())
 
-export const pruneSecrets = (): Promise<void> =>
-  withRetry('pruneSecrets', () => raw.pruneSecrets())
+export const pruneSecrets = async (): Promise<void> =>
+  withRetry('pruneSecrets', async () => raw.pruneSecrets())
 
 export const prunePodsAndServices = async (): Promise<void> => {
   await Promise.all([prunePods(), pruneServices()])
 }
 
-export const waitForPodPhases = (
+export const waitForPodPhases = async (
   podName: string,
   awaitingPhases: Set<PodPhase>,
   backOffPhases: Set<PodPhase>,
   maxTimeSeconds?: number
 ): Promise<void> =>
-  withRetry('waitForPodPhases', () =>
+  withRetry('waitForPodPhases', async () =>
     raw.waitForPodPhases(podName, awaitingPhases, backOffPhases, maxTimeSeconds)
   )
 
-export const waitForJobToComplete = (jobName: string): Promise<void> =>
-  withRetry('waitForJobToComplete', () => raw.waitForJobToComplete(jobName))
+export const waitForJobToComplete = async (jobName: string): Promise<void> =>
+  withRetry('waitForJobToComplete', async () =>
+    raw.waitForJobToComplete(jobName)
+  )
 
 // Not retried, re-exported unchanged
 
-export const getPodLogs = (
+export const getPodLogs = async (
   podName: string,
   containerName: string
 ): Promise<void> => raw.getPodLogs(podName, containerName)

--- a/packages/k8s/src/k8s/retry-wrappers.ts
+++ b/packages/k8s/src/k8s/retry-wrappers.ts
@@ -40,7 +40,7 @@ function isTransientError(err: unknown): boolean {
 
 // wrapped in an object so tests can mock the backoff delay
 const timers = {
-  sleep: (ms: number): Promise<void> =>
+  sleep: async (ms: number): Promise<void> =>
     new Promise(resolve => setTimeout(resolve, ms))
 }
 
@@ -156,4 +156,3 @@ export const getPrepareJobTimeoutSeconds = (): number =>
 export const isTransientErrorForTest = isTransientError
 export const withRetryForTest = withRetry
 export const timersForTest = timers
-

--- a/packages/k8s/src/k8s/retry-wrappers.ts
+++ b/packages/k8s/src/k8s/retry-wrappers.ts
@@ -38,8 +38,11 @@ function isTransientError(err: unknown): boolean {
   )
 }
 
-const sleep = (ms: number): Promise<void> =>
-  new Promise(resolve => setTimeout(resolve, ms))
+// wrapped in an object so tests can mock the backoff delay
+const timers = {
+  sleep: (ms: number): Promise<void> =>
+    new Promise(resolve => setTimeout(resolve, ms))
+}
 
 // exponential backoff + full jitter, bounded to a max_delay.
 async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
@@ -59,7 +62,7 @@ async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
           (err as { message?: string })?.message ?? err
         }`
       )
-      await sleep(delayMs)
+      await timers.sleep(delayMs)
     }
   }
 }
@@ -151,4 +154,6 @@ export const getPrepareJobTimeoutSeconds = (): number =>
 
 // Exposed for unit testing
 export const isTransientErrorForTest = isTransientError
+export const withRetryForTest = withRetry
+export const timersForTest = timers
 

--- a/packages/k8s/src/k8s/retry-wrappers.ts
+++ b/packages/k8s/src/k8s/retry-wrappers.ts
@@ -20,6 +20,11 @@ import { ContainerInfo, Registry } from 'hooklib'
 import * as raw from './index'
 import { PodPhase } from './utils'
 
+// error codes/messages considered transient
+const TRANSIENT_ERROR_PATTERN = /\bETIMEDOUT\b/
+// HTTP status codes considered transient
+const TRANSIENT_HTTP_STATUS_CODES = [429, 500, 502, 503, 504]
+
 // check if the error is a transient failure
 function isTransientError(err: unknown): boolean {
   const e = (err ?? {}) as Record<string, unknown>
@@ -28,15 +33,15 @@ function isTransientError(err: unknown): boolean {
     e.statusCode ?? (e.response as Record<string, unknown>)?.statusCode
   const msg = typeof e.message === 'string' ? e.message : String(err ?? '')
   return (
-    /\bETIMEDOUT\b/.test(`${code ?? ''} ${msg}`) ||
-    (typeof status === 'number' && [429, 500, 502, 503, 504].includes(status))
+    TRANSIENT_ERROR_PATTERN.test(`${code ?? ''} ${msg}`) ||
+    (typeof status === 'number' && TRANSIENT_HTTP_STATUS_CODES.includes(status))
   )
 }
 
 const sleep = (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms))
 
-// exponential backoff + full jitter, bounded to max_delay.
+// exponential backoff + full jitter, bounded to a max_delay.
 async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
   const attempts = 5
   const maxDelayMs = 8000
@@ -47,10 +52,10 @@ async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
       if (!isTransientError(err) || attempt >= attempts) {
         throw err
       }
-      const baseMs = 1000 * 2 ** (attempt - 1)
-      const delayMs = Math.min(maxDelayMs, Math.floor(baseMs + Math.random() * 1000))
+      const baseMs = Math.min(maxDelayMs, 1000 * 2 ** (attempt - 1))
+      const delayMs = Math.floor(baseMs * Math.random())
       core.warning(
-        `[k8s ${label}] transient error (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms: ${
+        `[${label}] transient error (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms: ${
           (err as { message?: string })?.message ?? err
         }`
       )
@@ -143,3 +148,7 @@ export const containerPorts = (
 
 export const getPrepareJobTimeoutSeconds = (): number =>
   raw.getPrepareJobTimeoutSeconds()
+
+// Exposed for unit testing
+export const isTransientErrorForTest = isTransientError
+

--- a/packages/k8s/src/k8s/retryWrappers.ts
+++ b/packages/k8s/src/k8s/retryWrappers.ts
@@ -1,0 +1,145 @@
+/**
+Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/**
+ * Retry wrapper over the raw Kubernetes helpers in ./index.ts
+ *
+ * Survive transient kube-apiserver connectivity blips
+ * (e.g. connect ETIMEDOUT <apiserver>:443) #DACH-NY/cn-test-failures/issues/8613
+ * The hook entrypoints import their k8s helpers from this module
+ * instead of from './index', so the wrapped calls are retried.
+ * Only transient errors(5xx, 429 etc) are retried
+ */
+
+import * as core from '@actions/core'
+import * as k8s from '@kubernetes/client-node'
+import { ContainerInfo, Registry } from 'hooklib'
+
+import * as raw from './index'
+import { PodPhase } from './utils'
+
+// check if the error is a transient failure
+function isTransientError(err: unknown): boolean {
+  const e = (err ?? {}) as Record<string, unknown>
+  const code = e.code ?? e.errno ?? (e.cause as Record<string, unknown>)?.code
+  const status =
+    e.statusCode ?? (e.response as Record<string, unknown>)?.statusCode
+  const msg = typeof e.message === 'string' ? e.message : String(err ?? '')
+  return (
+    /\bETIMEDOUT\b/.test(`${code ?? ''} ${msg}`) ||
+    (typeof status === 'number' && [429, 500, 502, 503, 504].includes(status))
+  )
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+// exponential backoff + full jitter, bounded to max_delay.
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const attempts = 5
+  const maxDelayMs = 8000
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!isTransientError(err) || attempt >= attempts) {
+        throw err
+      }
+      const baseMs = 1000 * 2 ** (attempt - 1)
+      const delayMs = Math.min(maxDelayMs, Math.floor(baseMs + Math.random() * 1000))
+      core.warning(
+        `[k8s ${label}] transient error (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms: ${
+          (err as { message?: string })?.message ?? err
+        }`
+      )
+      await sleep(delayMs)
+    }
+  }
+}
+
+// Retried API calls, only the ones the hooks import
+
+export const createPod = (
+  jobContainer?: k8s.V1Container,
+  services?: k8s.V1Container[],
+  registry?: Registry,
+  extension?: k8s.V1PodTemplateSpec
+): Promise<k8s.V1Pod> =>
+  withRetry('createPod', () =>
+    raw.createPod(jobContainer, services, registry, extension)
+  )
+
+export const createService = (pod: k8s.V1Pod): Promise<k8s.V1Service> =>
+  withRetry('createService', () => raw.createService(pod))
+
+export const createJob = (
+  container: k8s.V1Container,
+  extension?: k8s.V1PodTemplateSpec
+): Promise<k8s.V1Job> =>
+  withRetry('createJob', () => raw.createJob(container, extension))
+
+export const getContainerJobPodName = (jobName: string): Promise<string> =>
+  withRetry('getContainerJobPodName', () => raw.getContainerJobPodName(jobName))
+
+export const createSecretForEnvs = (envs: {
+  [key: string]: string
+}): Promise<string> =>
+  withRetry('createSecretForEnvs', () => raw.createSecretForEnvs(envs))
+
+export const getPodStatus = (
+  name: string
+): Promise<k8s.V1PodStatus | undefined> =>
+  withRetry('getPodStatus', () => raw.getPodStatus(name))
+
+export const isAuthPermissionsOK = (): Promise<boolean> =>
+  withRetry('isAuthPermissionsOK', () => raw.isAuthPermissionsOK())
+
+export const isPodContainerAlpine = (
+  podName: string,
+  containerName: string
+): Promise<boolean> =>
+  withRetry('isPodContainerAlpine', () =>
+    raw.isPodContainerAlpine(podName, containerName)
+  )
+
+export const prunePods = (): Promise<void> =>
+  withRetry('prunePods', () => raw.prunePods())
+
+export const pruneServices = (): Promise<void> =>
+  withRetry('pruneServices', () => raw.pruneServices())
+
+export const pruneSecrets = (): Promise<void> =>
+  withRetry('pruneSecrets', () => raw.pruneSecrets())
+
+export const prunePodsAndServices = async (): Promise<void> => {
+  await Promise.all([prunePods(), pruneServices()])
+}
+
+export const waitForPodPhases = (
+  podName: string,
+  awaitingPhases: Set<PodPhase>,
+  backOffPhases: Set<PodPhase>,
+  maxTimeSeconds?: number
+): Promise<void> =>
+  withRetry('waitForPodPhases', () =>
+    raw.waitForPodPhases(podName, awaitingPhases, backOffPhases, maxTimeSeconds)
+  )
+
+export const waitForJobToComplete = (jobName: string): Promise<void> =>
+  withRetry('waitForJobToComplete', () => raw.waitForJobToComplete(jobName))
+
+// Not retried, re-exported unchanged
+
+export const getPodLogs = (
+  podName: string,
+  containerName: string
+): Promise<void> => raw.getPodLogs(podName, containerName)
+
+export const containerPorts = (
+  container: ContainerInfo
+): k8s.V1ContainerPort[] => raw.containerPorts(container)
+
+export const getPrepareJobTimeoutSeconds = (): number =>
+  raw.getPrepareJobTimeoutSeconds()

--- a/packages/k8s/tests/retry-test.ts
+++ b/packages/k8s/tests/retry-test.ts
@@ -3,7 +3,11 @@ Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All r
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { isTransientErrorForTest as isTransientError } from '../src/k8s/retry-wrappers'
+import {
+  isTransientErrorForTest as isTransientError,
+  withRetryForTest as withRetry,
+  timersForTest as timers
+} from '../src/k8s/retry-wrappers'
 
 describe('transient error classification', () => {
   it('retries the apiserver ETIMEDOUT (code and message forms)', () => {
@@ -25,7 +29,8 @@ describe('transient error classification', () => {
     for (const statusCode of [400, 401, 403, 404, 409, 422]) {
       expect(isTransientError({ statusCode })).toBe(false)
     }
-    // Other socket errnos are no longer treated as transient.
+    // other socket errnos are not treated as transient for the time being,
+    // we can add later as needed
     for (const code of [
       'ECONNRESET',
       'ECONNREFUSED',
@@ -35,6 +40,32 @@ describe('transient error classification', () => {
     }
     expect(isTransientError(null)).toBe(false)
     expect(isTransientError(undefined)).toBe(false)
+  })
+})
+
+describe('withRetry', () => {
+  it('retries a transient failure', async () => {
+    // mock the 'sleep' via 'timers' to skip real backoff delay
+    jest.spyOn(timers, 'sleep').mockResolvedValue()
+
+    // fails twice with a transient error (ETIMEDOUT), then succeeds.
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('connect ETIMEDOUT 10.0.0.1:443'))
+      .mockRejectedValueOnce(new Error('connect ETIMEDOUT '))
+      .mockResolvedValue('recovered')
+
+    await expect(withRetry('label', fn)).resolves.toBe('recovered')
+    expect(fn).toHaveBeenCalledTimes(3)
+
+    // 2 transient failures + 1 success
+    const settled = await Promise.allSettled(fn.mock.results.map(r => r.value))
+    const failures = settled.filter(s => s.status === 'rejected')
+    const successes = settled.filter(s => s.status === 'fulfilled')
+    expect(failures).toHaveLength(2)
+    expect(successes).toHaveLength(1)
+
+    jest.restoreAllMocks()
   })
 })
 

--- a/packages/k8s/tests/retry-test.ts
+++ b/packages/k8s/tests/retry-test.ts
@@ -10,7 +10,7 @@ import {
 } from '../src/k8s/retry-wrappers'
 
 describe('transient error classification', () => {
-  it('retries the apiserver ETIMEDOUT (code and message forms)', () => {
+  it('classifies apiserver ETIMEDOUT as transient error', () => {
     expect(isTransientError({ code: 'ETIMEDOUT' })).toBe(true)
     expect(isTransientError({ cause: { code: 'ETIMEDOUT' } })).toBe(true)
     expect(isTransientError(new Error('connect ETIMEDOUT 34.18.24.1:443'))).toBe(
@@ -18,14 +18,14 @@ describe('transient error classification', () => {
     )
   })
 
-  it('retries 429 and 5xx http status codes', () => {
+  it('classifies 429 and 5xx http status codes as transient error', () => {
     for (const statusCode of [429, 500, 502, 503, 504]) {
       expect(isTransientError({ statusCode })).toBe(true)
     }
     expect(isTransientError({ response: { statusCode: 503 } })).toBe(true)
   })
 
-  it('does NOT retry non-transient errors', () => {
+  it('classifies 4xx (except 429) as non-transient error', () => {
     for (const statusCode of [400, 401, 403, 404, 409, 422]) {
       expect(isTransientError({ statusCode })).toBe(false)
     }

--- a/packages/k8s/tests/retry-test.ts
+++ b/packages/k8s/tests/retry-test.ts
@@ -1,0 +1,40 @@
+/**
+Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { isTransientErrorForTest as isTransient } from '../src/k8s/retry-wrappers'
+
+describe('k8s apiserver retry classification', () => {
+  it('retries the apiserver ETIMEDOUT (code and message forms)', () => {
+    expect(isTransient({ code: 'ETIMEDOUT' })).toBe(true)
+    expect(isTransient({ cause: { code: 'ETIMEDOUT' } })).toBe(true)
+    expect(isTransient(new Error('connect ETIMEDOUT 34.18.24.1:443'))).toBe(
+      true
+    )
+  })
+
+  it('retries 429 and 5xx', () => {
+    for (const statusCode of [429, 500, 502, 503, 504]) {
+      expect(isTransient({ statusCode })).toBe(true)
+    }
+    expect(isTransient({ response: { statusCode: 503 } })).toBe(true)
+  })
+
+  it('does NOT retry non-transient errors', () => {
+    for (const statusCode of [400, 401, 403, 404, 409, 422]) {
+      expect(isTransient({ statusCode })).toBe(false)
+    }
+    // Other socket errnos are no longer treated as transient.
+    for (const code of [
+      'ECONNRESET',
+      'ECONNREFUSED',
+      'ECONNABORTED',
+    ]) {
+      expect(isTransient({ code })).toBe(false)
+    }
+    expect(isTransient(null)).toBe(false)
+    expect(isTransient(undefined)).toBe(false)
+  })
+})
+

--- a/packages/k8s/tests/retry-test.ts
+++ b/packages/k8s/tests/retry-test.ts
@@ -3,27 +3,27 @@ Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All r
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { isTransientErrorForTest as isTransient } from '../src/k8s/retry-wrappers'
+import { isTransientErrorForTest as isTransientError } from '../src/k8s/retry-wrappers'
 
-describe('k8s apiserver retry classification', () => {
+describe('transient error classification', () => {
   it('retries the apiserver ETIMEDOUT (code and message forms)', () => {
-    expect(isTransient({ code: 'ETIMEDOUT' })).toBe(true)
-    expect(isTransient({ cause: { code: 'ETIMEDOUT' } })).toBe(true)
-    expect(isTransient(new Error('connect ETIMEDOUT 34.18.24.1:443'))).toBe(
+    expect(isTransientError({ code: 'ETIMEDOUT' })).toBe(true)
+    expect(isTransientError({ cause: { code: 'ETIMEDOUT' } })).toBe(true)
+    expect(isTransientError(new Error('connect ETIMEDOUT 34.18.24.1:443'))).toBe(
       true
     )
   })
 
-  it('retries 429 and 5xx', () => {
+  it('retries 429 and 5xx http status codes', () => {
     for (const statusCode of [429, 500, 502, 503, 504]) {
-      expect(isTransient({ statusCode })).toBe(true)
+      expect(isTransientError({ statusCode })).toBe(true)
     }
-    expect(isTransient({ response: { statusCode: 503 } })).toBe(true)
+    expect(isTransientError({ response: { statusCode: 503 } })).toBe(true)
   })
 
   it('does NOT retry non-transient errors', () => {
     for (const statusCode of [400, 401, 403, 404, 409, 422]) {
-      expect(isTransient({ statusCode })).toBe(false)
+      expect(isTransientError({ statusCode })).toBe(false)
     }
     // Other socket errnos are no longer treated as transient.
     for (const code of [
@@ -31,10 +31,10 @@ describe('k8s apiserver retry classification', () => {
       'ECONNREFUSED',
       'ECONNABORTED',
     ]) {
-      expect(isTransient({ code })).toBe(false)
+      expect(isTransientError({ code })).toBe(false)
     }
-    expect(isTransient(null)).toBe(false)
-    expect(isTransient(undefined)).toBe(false)
+    expect(isTransientError(null)).toBe(false)
+    expect(isTransientError(undefined)).toBe(false)
   })
 })
 


### PR DESCRIPTION
[static]

Fixes: https://github.com/DACH-NY/cn-test-failures/issues/8613

- RetryWrapper for API calls between gha runner and the k8s api-server. 
- Transient errors in the API calls are costly, (a) as we need to re-run the whole CI pipeline, (b) frequent flakes from GHA `post main`
- This is a draft, if the approach makes sense, we can tighten/test and merge. (one concern is doing this change in the fork)